### PR TITLE
Force column types of join tables to be bigint too.

### DIFF
--- a/lib/bigint_pk.rb
+++ b/lib/bigint_pk.rb
@@ -19,6 +19,7 @@ module BigintPk
   def self.install_patches!
     install_primary_key_patches!
     install_foreign_key_patches!
+    install_create_join_table_patches!
   end
 
   def self.install_primary_key_patches!
@@ -55,6 +56,20 @@ module BigintPk
         end
         alias_method_chain :references, :default_bigint_fk
       end
+    end
+  end
+
+  def self.install_create_join_table_patches!
+    ActiveRecord::ConnectionAdapters::SchemaStatements.class_eval do
+      def create_join_table_with_bigint_keys *args
+        options = args.extract_options!
+        column_options = options.delete(:column_options) || {}
+        column_options.reverse_merge!(type: :bigint)
+        options[:column_options] = column_options
+
+        create_join_table_without_bigint_keys( *args, options )
+      end
+      alias_method_chain :create_join_table, :bigint_keys
     end
   end
 end


### PR DESCRIPTION
For my application, I needed all of my primary keys to be bigint due to some legacy data that I will be importing.

I installed this gem, but upon generating my first join table, I found that the column types in that join table were still integer, and that the migration generated by this gem ignored those tables.

I haven't fixed the second part, but I believe I've fixed the first - column types in join tables are now bigint, as expected. I'm not sure how to go about writing a test to cover this, but I'm happy to do so if someone can give me a few pointers in the right direction.

If this patch isn't useful, please feel free to ignore :)
