### PR TITLE
Fix the gem for tables without PK

### DIFF
--- a/lib/generators/bigint_pk/install_generator.rb
+++ b/lib/generators/bigint_pk/install_generator.rb
@@ -31,7 +31,7 @@ module BigintPk
           end
 
           options[:klass] ||= klass
-          options[:set_primary_key] = klass.columns_hash[klasses.last.primary_key].sql_type != DESTINATION_TYPE
+          options[:set_primary_key] = klass.primary_key && klass.columns_hash[klass.primary_key].sql_type != DESTINATION_TYPE
           options[:references] ||= []
           options[:references].concat belongs_to_associations.map {|association| association.foreign_key }
           options[:references].uniq!

--- a/lib/generators/bigint_pk/templates/migration.rb.erb
+++ b/lib/generators/bigint_pk/templates/migration.rb.erb
@@ -18,7 +18,7 @@ class <%= @name.camelize %> < ActiveRecord::Migration
   def self.down
     Lhm.change_table :<%= @klass.table_name %> do |m|
       <%- if @set_primary_key -%>
-      m.change_column :<%= @klass.primary_key %>, "INT(11)" if @set_primary_key
+      m.change_column :<%= @klass.primary_key %>, "INT(11)"
       <%- end -%>
 
       <%- @references.each do |reference| -%>


### PR DESCRIPTION
This fixes the gem for tables that don't have PKs or for which the PK is not the same as the last table picked up by `ActiveRecord`
