### PR TITLE
Generate migrations without spaces

### DIFF
--- a/lib/generators/bigint_pk/install_generator.rb
+++ b/lib/generators/bigint_pk/install_generator.rb
@@ -42,7 +42,7 @@ module BigintPk
         end
 
         version = Time.now.utc.strftime('%Y%m%d%H%M%S')
-        prefix = Time.now.utc.strftime('%b%e').downcase
+        prefix = Time.now.utc.strftime('%b%d').downcase
         number = 0
         tables.each do |table_name, options|
           @klass = options[:klass]


### PR DESCRIPTION
"%e" pads the day of the month with a space. "%" pads it with a zero"

"feb 4" vs "feb04"

@Krystosterone @jpcaissy 
