### PR TITLE
Remove deprecations

### DIFF
--- a/.rspec
+++ b/.rspec
@@ -1,2 +1,1 @@
 --colour
---debugger

--- a/lib/bigint_pk.rb
+++ b/lib/bigint_pk.rb
@@ -35,26 +35,26 @@ module BigintPk
     end
   end
 
+  module DefaultBigintForeignKeyReferences
+    def references(*args)
+      options = args.extract_options!
+      options.reverse_merge! limit: 8
+      # Limit shouldn't affect "#{col}_type" column in polymorphic reference.
+      # But don't change value if it isn't simple 'true'.
+      # Examples:
+      #   t.references :subject, null: false, polymorphic: true ==> t.integer :subject_id, limit: 8, null: false
+      #                                                             t.string  :subject_type, null: false
+      #   t.references :subject, polymorphic: { limit: 120 }    ==> t.integer :subject_id, limit: 8
+      #                                                             t.string  :subject_type, limit: 120
+      options[:polymorphic] = options.except(:polymorphic, :limit) if options[:polymorphic] == true
+      super( *args, options )
+    end
+  end
+
   def self.install_foreign_key_patches!
     [   ActiveRecord::ConnectionAdapters::TableDefinition,
         ActiveRecord::ConnectionAdapters::Table].each do |abstract_table_type|
-
-      abstract_table_type.class_eval do
-        def references_with_default_bigint_fk *args
-          options = args.extract_options!
-          options.reverse_merge! limit: 8
-          # Limit shouldn't affect "#{col}_type" column in polymorphic reference.
-          # But don't change value if it isn't simple 'true'.
-          # Examples:
-          #   t.references :subject, null: false, polymorphic: true ==> t.integer :subject_id, limit: 8, null: false
-          #                                                             t.string  :subject_type, null: false
-          #   t.references :subject, polymorphic: { limit: 120 }    ==> t.integer :subject_id, limit: 8
-          #                                                             t.string  :subject_type, limit: 120
-          options[:polymorphic] = options.except(:polymorphic, :limit) if options[:polymorphic] == true 
-          references_without_default_bigint_fk( *args, options )
-        end
-        alias_method_chain :references, :default_bigint_fk
-      end
+      abstract_table_type.prepend(DefaultBigintForeignKeyReferences)
     end
   end
 end

--- a/rails-bigint-pk.gemspec
+++ b/rails-bigint-pk.gemspec
@@ -24,9 +24,7 @@ Gem::Specification.new do |s|
   s.add_development_dependency "rspec"
   s.add_development_dependency "travis-lint"
   s.add_development_dependency "rails"
-  s.add_development_dependency "debugger"
   s.add_development_dependency "mysql2", '~> 0.3.10'
-  s.add_development_dependency "mysql", '~> 2.8.1'
   s.add_development_dependency "pg", '~> 0.11'
   s.add_development_dependency "sqlite3", '~> 1.3.6'
   s.add_development_dependency "guard"


### PR DESCRIPTION
This removes deprecations for Rails 5. 
I have no idea how to run the tests. 

I manually tested and everything seems to still work
