### PR TITLE
Remove DEFAULT NULL to support MySQL 5.7

### DIFF
--- a/lib/bigint_pk.rb
+++ b/lib/bigint_pk.rb
@@ -30,7 +30,7 @@ module BigintPk
     end
 
     if ca.const_defined? :AbstractMysqlAdapter
-      ca::AbstractMysqlAdapter::NATIVE_DATABASE_TYPES[:primary_key] = 'bigint(20) DEFAULT NULL auto_increment PRIMARY KEY'
+      ca::AbstractMysqlAdapter::NATIVE_DATABASE_TYPES[:primary_key] = 'bigint(20) auto_increment PRIMARY KEY'
       ca::AbstractMysqlAdapter::NATIVE_DATABASE_TYPES[:integer] = { :name => "bigint", :limit => 6 }
     end
   end

--- a/spec/monkey_patch/connection_adapters_spec.rb
+++ b/spec/monkey_patch/connection_adapters_spec.rb
@@ -39,7 +39,7 @@ describe BigintPk do
         expect(
           ActiveRecord::ConnectionAdapters::AbstractMysqlAdapter::
             NATIVE_DATABASE_TYPES[:primary_key]
-        ).to eq 'bigint(20) DEFAULT NULL auto_increment PRIMARY KEY'
+        ).to eq 'bigint(20) auto_increment PRIMARY KEY'
       end
 
       def self.it_makes_references_default_to_64bit
@@ -142,7 +142,7 @@ describe BigintPk do
         expect(
           ActiveRecord::ConnectionAdapters::AbstractMysqlAdapter::
             NATIVE_DATABASE_TYPES[:primary_key]
-        ).to eq 'int(11) DEFAULT NULL auto_increment PRIMARY KEY'
+        ).to eq 'int auto_increment PRIMARY KEY'
       end
     end
   end


### PR DESCRIPTION
Primary keys should be NOT NULL so we can't define them with NULL as default. In versions of MySQL previous to 5.7 this option was just ignored, now it raises an error.

This same change was made in https://github.com/rails/rails/pull/13247.

Review @gmalette @Shopify/datastores 
