### PR TITLE
Fix automatic enabling of this gem

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -5,7 +5,7 @@ cache:
 rvm:
   - "2.2.6"
   - "2.3.3"
-gemfiles:
+gemfile:
   - Gemfile
   - test/gemfiles/Gemfile-Rails-4.2
 env:

--- a/lib/bigint_pk/railtie.rb
+++ b/lib/bigint_pk/railtie.rb
@@ -2,8 +2,6 @@ require 'rails/railtie'
 
 class BigintPk::Railtie < Rails::Railtie
   initializer 'bigint_pk.install' do
-    ActiveSupport.on_load(:active_record) do
-      BigintPk.enable!
-    end
+    BigintPk.enable! if defined?(ActiveRecord)
   end
 end

--- a/lib/rails-bigint-pk.rb
+++ b/lib/rails-bigint-pk.rb
@@ -1,0 +1,1 @@
+require 'bigint_pk'


### PR DESCRIPTION
This gem was not automatically enabling when doing:

```
gem 'rails-bigint-pk'
```

because there is no rails-bigint-pk.rb file in the lib directory.

Also I change the hook to not expect `ActiveRecord::Base` to be loaded to enable this gem but still check for `ActiveRecord`.

And, finally fixed the travis matrix to run tests with Rails 4.2

cc @camilo @sroysen 