### PR TITLE
Rails 5 support and add missing auto increment / sequence

### DIFF
--- a/lib/bigint_pk.rb
+++ b/lib/bigint_pk.rb
@@ -11,6 +11,16 @@ module BigintPk
 
   private
 
+  module DefaultBigintPrimaryKey
+    def primary_key(name, type = :primary_key, **options)
+      if type == :primary_key
+        super(name, :bigint, **options)
+      else
+        super
+      end
+    end
+  end
+
   module PostgresBigintPrimaryKey
     def primary_key(name, type = :primary_key, **options)
       if type == :primary_key
@@ -64,7 +74,7 @@ module BigintPk
 
     [ca::TableDefinition,
      ca::Table].each do |abstract_table_type|
-      abstract_table_type.prepend(pk_module)
+      abstract_table_type.prepend(pk_module || DefaultBigintPrimaryKey)
       abstract_table_type.prepend(DefaultBigintForeignKeyReferences)
     end
   end

--- a/lib/bigint_pk.rb
+++ b/lib/bigint_pk.rb
@@ -59,14 +59,13 @@ module BigintPk
   end
 
   def install_patches!
-    ca = ActiveRecord::ConnectionAdapters
+    ca   = ActiveRecord::ConnectionAdapters
+    conf = ca::ConnectionSpecification::Resolver.new(ActiveRecord::Base.configurations).configurations[Rails.env]
 
-    if ca.const_defined? :PostgreSQLAdapter
+    if conf['adapter'] == 'postgresql'
       pk_module = PostgresBigintPrimaryKey
       ca::PostgreSQLAdapter::NATIVE_DATABASE_TYPES[:primary_key] = 'bigserial primary key'
-    end
-
-    if ca.const_defined? :AbstractMysqlAdapter
+    elsif conf['adapter'] =~ /mysql\d+/
       pk_module = MysqlBigintPrimaryKey
       ca::AbstractMysqlAdapter::NATIVE_DATABASE_TYPES[:primary_key] = 'bigint(20) auto_increment PRIMARY KEY'
       ca::AbstractMysqlAdapter::NATIVE_DATABASE_TYPES[:integer] = { :name => "bigint", :limit => 6 }

--- a/test/conf/mysql2.yml
+++ b/test/conf/mysql2.yml
@@ -1,0 +1,3 @@
+test:
+  adapter: mysql2
+  database: bigint_test

--- a/test/conf/postgresql.yml
+++ b/test/conf/postgresql.yml
@@ -1,0 +1,3 @@
+test:
+  adapter: postgresql
+  database: bigint_test

--- a/test/gemfiles/Gemfile-Rails-4.2
+++ b/test/gemfiles/Gemfile-Rails-4.2
@@ -3,5 +3,4 @@ source "https://rubygems.org"
 # Specify your gem's dependencies in rails-bigint-pk.gemspec
 gemspec path: "../.."
 
-gem 'activerecord', '~> 4.2.0'
-gem 'railties', '~> 4.2.0'
+gem 'rails', '~> 4.2.0'

--- a/test/gemfiles/Gemfile-Rails-5.0
+++ b/test/gemfiles/Gemfile-Rails-5.0
@@ -3,5 +3,4 @@ source "https://rubygems.org"
 # Specify your gem's dependencies in rails-bigint-pk.gemspec
 gemspec path: "../.."
 
-gem 'activerecord', '~> 5.0.0'
-gem 'railties', '~> 5.0.0'
+gem 'rails', '~> 5.0.0'

--- a/test/gemfiles/Gemfile-Rails-5.0
+++ b/test/gemfiles/Gemfile-Rails-5.0
@@ -1,0 +1,7 @@
+source "https://rubygems.org"
+
+# Specify your gem's dependencies in rails-bigint-pk.gemspec
+gemspec path: "../.."
+
+gem 'activerecord', '~> 5.0.0'
+gem 'railties', '~> 5.0.0'

--- a/test/migration_test.rb
+++ b/test/migration_test.rb
@@ -1,12 +1,11 @@
 require 'minitest/autorun'
 require 'bigint_pk'
 
-BigintPk.enable!
-
 class MigrationTest < Minitest::Test
   def setup
     super
     ActiveRecord::Base.establish_connection(adapter: ENV['ADAPTER'] || "mysql2", database: "bigint_test")
+    BigintPk.enable!
   end
 
   def teardown
@@ -22,8 +21,10 @@ class MigrationTest < Minitest::Test
     assert_equal [:integer], columns.map(&:type)
     if ENV['ADAPTER'] == 'postgresql'
       assert_equal ['bigint'], columns.map(&:sql_type)
+      assert_equal "nextval('foo_id_seq'::regclass)", connection.exec_query("SELECT column_default FROM information_schema.columns WHERE table_name = 'foo' AND column_name = 'id'").first['column_default']
     else
       assert_equal ['bigint(20)'], columns.map(&:sql_type)
+      assert_equal '`id` bigint(20) NOT NULL AUTO_INCREMENT', connection.exec_query('SHOW CREATE TABLE `foo`').first['Create Table'].match(/`id`[^,\n]+/)[0]
     end
     assert_equal [8], columns.map(&:limit)
   end


### PR DESCRIPTION
This pull adds Rails 5 support and creation of the auto increment (MySQL) or sequence (Postgres). I couldn't use this without these features, how did you guys use it until now without the ids being auto generated? :)